### PR TITLE
Updated setup.txt to correct missing /opt

### DIFF
--- a/setup.txt
+++ b/setup.txt
@@ -36,7 +36,7 @@ Tool Installation
 The Backdoor Factory:
 ●	Patch PE, ELF, Mach-O binaries with shellcode.
 ●	git clone https://github.com/secretsquirrel/the-backdoor-factory /opt/the-backdoor-factory
-●	cd the-backdoor-factory
+●	cd /opt/the-backdoor-factory
 ●	./install.sh
 
 HTTPScreenShot

--- a/setup.txt
+++ b/setup.txt
@@ -143,6 +143,7 @@ DSHashes:
 SPARTA:
 ●	A python GUI application which simplifies network infrastructure penetration testing by aiding the penetration tester in the scanning and enumeration phase.
 ●	git clone https://github.com/secforce/sparta.git /opt/sparta
+●	apt-get update (This prevents failure when attempting to retrieve python-elixir - May not be required in all cases)
 ●	apt-get install python-elixir
 ●	apt-get install ldap-utils rwho rsh-client x11-apps finger
 


### PR DESCRIPTION
The step to install the back door factory tool was missing the leading /opt directory.  Added it.
